### PR TITLE
Fix overlay crashes and incorrect text from strings with % characters

### DIFF
--- a/Util/Overlay/WindowsOverlayService.cs
+++ b/Util/Overlay/WindowsOverlayService.cs
@@ -324,7 +324,7 @@ namespace Archipelago.Core.Util.Overlay
                 color.W *= opacity;
 
                 ImGui.PushStyleColor(ImGuiCol.Text, color);
-                ImGui.Text(span.Text);
+                ImGui.TextUnformatted(span.Text);
                 ImGui.PopStyleColor();
 
                 previousFontKey = spanFontKey;


### PR DESCRIPTION
ImGui.Text() treats the 1st input argument like a format string for printf(), so having "% T" in a message that goes to the overlay crashes the program.

This was also eating my string "from 100% to 140%" and changing it to "from 1000 140"

TextUnformatted() doesn't have that behavior.