### PR TITLE
Improve Linux Compatibility with PCSX2

### DIFF
--- a/ArchipelagoClient.cs
+++ b/ArchipelagoClient.cs
@@ -93,7 +93,7 @@ namespace Archipelago.Core
 
         public ArchipelagoClient(IGameClient gameClient)
         {
-            if (gameClient.ProcId != 0 && ElevationHelper.RequiresElevation(gameClient.ProcId))
+            if (gameClient.ProcId != 0 && !PlatformMemory.HasDirectMapping && ElevationHelper.RequiresElevation(gameClient.ProcId))
             {
                 Log.Warning("Process {ProcessId} requires elevated privileges. Memory operations will fail without administrator access.", gameClient.ProcId);
                 if (!ElevationHelper.IsElevated())

--- a/Util/PCSX2/PCSX2MemoryHelper.cs
+++ b/Util/PCSX2/PCSX2MemoryHelper.cs
@@ -1,4 +1,4 @@
-﻿using Serilog;
+using Serilog;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -26,53 +26,62 @@ namespace Archipelago.Core.Util.PCSX2
 
             // Find the PCSX2 module base address
             IntPtr moduleBase = PlatformMemory.PlatformMemory.GetModuleBaseAddress(pid, PCSX2_MODULE_NAME);
-            if (moduleBase == IntPtr.Zero)
+            IntPtr eememExportAddress = IntPtr.Zero;
+            if (moduleBase != IntPtr.Zero)
             {
-                Log.Logger.Warning("Failed to find PCSX2 module");
-                return IntPtr.Zero;
+                // Find the EEmem export in the module
+                eememExportAddress = PlatformMemory.PlatformMemory.GetExportAddress(pid, moduleBase, EEMEM_EXPORT_NAME);
             }
-
-            // Find the EEmem export in the module
-            IntPtr eememExportAddress = PlatformMemory.PlatformMemory.GetExportAddress(pid, moduleBase, EEMEM_EXPORT_NAME);
-            if (eememExportAddress == IntPtr.Zero)
+            if (eememExportAddress != IntPtr.Zero)
             {
-                Log.Logger.Warning("Failed to find EEmem export");
-                return IntPtr.Zero;
-            }
-
-            // Open a handle to the process for reading
-            IntPtr processHandle = PlatformMemory.PlatformMemory.PlatformImpl.OpenProcess(
-                PlatformMemory.PlatformMemory.PROCESS_VM_READ | PlatformMemory.PlatformMemory.PROCESS_VM_OPERATION,
-                false, pid);
-
-            if (processHandle == IntPtr.Zero)
-            {
-                Log.Logger.Error("Failed to open PCSX2 process");
-                return IntPtr.Zero;
-            }
-
-            try
-            {
-                // Read the pointer value at the EEmem export address
-                byte[] buffer = new byte[IntPtr.Size];
-                if (!PlatformMemory.PlatformMemory.PlatformImpl.ReadProcessMemory(processHandle, (ulong)eememExportAddress,
-                    buffer, buffer.Length, out IntPtr bytesRead))
+                // Open a handle to the process for reading
+                IntPtr processHandle = PlatformMemory.PlatformMemory.PlatformImpl.OpenProcess(
+                    PlatformMemory.PlatformMemory.PROCESS_VM_READ | PlatformMemory.PlatformMemory.PROCESS_VM_OPERATION,
+                    false, pid);
+                
+                if (processHandle == IntPtr.Zero)
                 {
-                    Log.Logger.Warning("Failed to read EEmem pointer value");
+                    Log.Logger.Error("Failed to open PCSX2 process");
                     return IntPtr.Zero;
                 }
 
-                // Convert buffer to pointer
-                IntPtr eememBaseAddress = (IntPtr)BitConverter.ToInt64(buffer, 0);
+                try
+                {
+                    // Read the pointer value at the EEmem export address
+                    byte[] buffer = new byte[IntPtr.Size];
+                    if (!PlatformMemory.PlatformMemory.PlatformImpl.ReadProcessMemory(processHandle, (ulong)eememExportAddress,
+                        buffer, buffer.Length, out IntPtr bytesRead))
+                    {
+                        Log.Logger.Warning("Failed to read EEmem pointer value");
+                        return IntPtr.Zero;
+                    }
 
-                Log.Logger.Information($"Found PCSX2 EEmem at 0x{eememBaseAddress:X}");
-                return eememBaseAddress;
+                    // Convert buffer to pointer
+                    IntPtr eememBaseAddress = (IntPtr)BitConverter.ToInt64(buffer, 0);
+                    
+                    Log.Logger.Information($"Found PCSX2 EEmem at 0x{eememBaseAddress:X}");
+                    return eememBaseAddress;
+                }
+                finally
+                {
+                    PlatformMemory.PlatformMemory.PlatformImpl.CloseHandle(processHandle);
+                }
             }
-            finally
+
+            // Linux fallback: attach PCSX2's named shared memory directly
+            if (OperatingSystem.IsLinux())
             {
-                PlatformMemory.PlatformMemory.PlatformImpl.CloseHandle(processHandle);
+                IntPtr shmBase = PlatformMemory.PlatformMemory.FindSharedMemoryBase(pid, "pcsx2");
+                if (shmBase != IntPtr.Zero)
+                {
+                    PlatformMemory.PlatformMemory.AttachSharedMemory($"pcsx2_{pid}", (ulong)shmBase);
+                    Log.Logger.Warning($"EEmem symbol not found; using shared memory base 0x{shmBase:X} (EEmemOffset == 0)");
+                    return shmBase;
+                }
             }
+
+            Log.Logger.Warning("Failed to find EEmem export");
+            return IntPtr.Zero;
         }
     }
 }
-

--- a/Util/PCSX2/PCSX2MemoryHelper.cs
+++ b/Util/PCSX2/PCSX2MemoryHelper.cs
@@ -12,76 +12,96 @@ namespace Archipelago.Core.Util.PCSX2
     internal class PCSX2MemoryHelper
     {
         private const string PCSX2_MODULE_NAME = "pcsx2-qt";
+        private const string PCSX2_MODULE_FALLBACK_NAME = "pcsx2";
         private const string EEMEM_EXPORT_NAME = "EEmem";
 
         public IntPtr FindEEromAddress()
         {
             // Get the PCSX2 process ID
+            // Might be worth discussing using GetProcessIDs here and selecting the newest process instead?
             int pid = PlatformMemory.PlatformMemory.GetProcessID(PCSX2_MODULE_NAME);
+            // Some distributions run as 'pcsx2', so a quick fallback here helps with compatibility
+            pid = pid == 0 ? PlatformMemory.PlatformMemory.GetProcessID(PCSX2_MODULE_FALLBACK_NAME) : pid;
             if (pid == 0)
             {
                 Log.Logger.Warning("PCSX2 process not found");
                 return IntPtr.Zero;
             }
-
-            // Find the PCSX2 module base address
-            IntPtr moduleBase = PlatformMemory.PlatformMemory.GetModuleBaseAddress(pid, PCSX2_MODULE_NAME);
-            IntPtr eememExportAddress = IntPtr.Zero;
-            if (moduleBase != IntPtr.Zero)
-            {
-                // Find the EEmem export in the module
-                eememExportAddress = PlatformMemory.PlatformMemory.GetExportAddress(pid, moduleBase, EEMEM_EXPORT_NAME);
-            }
-            if (eememExportAddress != IntPtr.Zero)
-            {
-                // Open a handle to the process for reading
-                IntPtr processHandle = PlatformMemory.PlatformMemory.PlatformImpl.OpenProcess(
-                    PlatformMemory.PlatformMemory.PROCESS_VM_READ | PlatformMemory.PlatformMemory.PROCESS_VM_OPERATION,
-                    false, pid);
-                
-                if (processHandle == IntPtr.Zero)
-                {
-                    Log.Logger.Error("Failed to open PCSX2 process");
-                    return IntPtr.Zero;
-                }
-
-                try
-                {
-                    // Read the pointer value at the EEmem export address
-                    byte[] buffer = new byte[IntPtr.Size];
-                    if (!PlatformMemory.PlatformMemory.PlatformImpl.ReadProcessMemory(processHandle, (ulong)eememExportAddress,
-                        buffer, buffer.Length, out IntPtr bytesRead))
-                    {
-                        Log.Logger.Warning("Failed to read EEmem pointer value");
-                        return IntPtr.Zero;
-                    }
-
-                    // Convert buffer to pointer
-                    IntPtr eememBaseAddress = (IntPtr)BitConverter.ToInt64(buffer, 0);
-                    
-                    Log.Logger.Information($"Found PCSX2 EEmem at 0x{eememBaseAddress:X}");
-                    return eememBaseAddress;
-                }
-                finally
-                {
-                    PlatformMemory.PlatformMemory.PlatformImpl.CloseHandle(processHandle);
-                }
-            }
-
-            // Linux fallback: attach PCSX2's named shared memory directly
+            
+            // Preferred Linux Method, try to access shared memory exposed by PCSX2
+            // Currently, not supported in main PCSX2 build, so we try our best
+            // but fall back happily for older versions of PCSX2
             if (OperatingSystem.IsLinux())
             {
                 IntPtr shmBase = PlatformMemory.PlatformMemory.FindSharedMemoryBase(pid, "pcsx2");
                 if (shmBase != IntPtr.Zero)
                 {
                     PlatformMemory.PlatformMemory.AttachSharedMemory($"pcsx2_{pid}", (ulong)shmBase);
-                    Log.Logger.Warning($"EEmem symbol not found; using shared memory base 0x{shmBase:X} (EEmemOffset == 0)");
+                    Log.Logger.Debug($"Found shared memory base 0x{shmBase:X}");
                     return shmBase;
                 }
+                // Log verbose to show the program execution flow without scaring users while we wait for compatibility.
+                Log.Logger.Verbose("Couldn't find shm from PCSX2. This is currently expected.");
+                // In future when supported by PCSX2 officially,
+                // we can let Logger know they are probably using an outdated version 
+                // Log.Logger.Debug("Could not find Shared Memory. Are you using an older version of PCSX2?");
+            }
+            
+            // Find the PCSX2 module base address
+            IntPtr moduleBase = PlatformMemory.PlatformMemory.GetModuleBaseAddress(pid, PCSX2_MODULE_NAME);
+            if (moduleBase == IntPtr.Zero)
+            {
+                Log.Logger.Warning("Failed to find PCSX2 module");
+                return IntPtr.Zero;
             }
 
-            Log.Logger.Warning("Failed to find EEmem export");
-            return IntPtr.Zero;
+            // Find the EEmem export in the module
+            IntPtr eememExportAddress = PlatformMemory.PlatformMemory.GetExportAddress(pid, moduleBase, EEMEM_EXPORT_NAME);
+            if (eememExportAddress == IntPtr.Zero)
+            {
+                Log.Logger.Warning("Failed to find EEmem export.");
+                if (OperatingSystem.IsLinux())
+                {
+                    // pcsx2 binary symbols are commonly stripped on Linux, which is apparently unintended behaviour,
+                    // but the Flatpak is known to preserve them, so direct the user to try the Flatpak.
+                    Log.Logger.Warning("You may have better luck locating EEmem with the Flatpak build.");
+                }
+                return IntPtr.Zero;
+            }
+
+            // Open a handle to the process for reading
+            IntPtr processHandle = PlatformMemory.PlatformMemory.PlatformImpl.OpenProcess(
+                PlatformMemory.PlatformMemory.PROCESS_VM_READ | PlatformMemory.PlatformMemory.PROCESS_VM_OPERATION,
+                false, pid);
+
+            if (processHandle == IntPtr.Zero)
+            {
+                Log.Logger.Error("Failed to open PCSX2 process");
+                return IntPtr.Zero;
+            }
+
+            try
+            {
+                // Read the pointer value at the EEmem export address
+                byte[] buffer = new byte[IntPtr.Size];
+                if (!PlatformMemory.PlatformMemory.PlatformImpl.ReadProcessMemory(processHandle, (ulong)eememExportAddress,
+                    buffer, buffer.Length, out IntPtr bytesRead))
+                {
+                    Log.Logger.Warning("Failed to read EEmem pointer value");
+                    return IntPtr.Zero;
+                }
+
+                // Convert buffer to pointer
+                IntPtr eememBaseAddress = (IntPtr)BitConverter.ToInt64(buffer, 0);
+
+                Log.Logger.Information($"Found PCSX2 EEmem at 0x{eememBaseAddress:X}");
+                return eememBaseAddress;
+            }
+            finally
+            {
+                PlatformMemory.PlatformMemory.PlatformImpl.CloseHandle(processHandle);
+            }
         }
     }
 }
+

--- a/Util/PlatformMemory.cs
+++ b/Util/PlatformMemory.cs
@@ -209,6 +209,20 @@ namespace Archipelago.Core.Util.PlatformMemory
             if (CurrentProcId == 0) throw new ArgumentException("CurrentProcId has not been set");
             return PlatformImpl.VirtualFreeEx(CurrentHandle(), address, IntPtr.Zero, MEM_RELEASE);
         }
+        
+        public static IntPtr FindSharedMemoryBase(int pid, string nameSubstring)
+        {
+            if (PlatformImpl is LinuxMemory linux)
+                return linux.FindSharedMemoryBase(pid, nameSubstring);
+            return IntPtr.Zero;
+        }
+        
+        public static nint AttachSharedMemory(string shmName, ulong remoteBase)
+        {
+            if (PlatformImpl is LinuxMemory linux)
+                return linux.AttachSharedMemory(shmName, remoteBase);
+            return nint.Zero;
+        }
         #endregion
         #region Remote Execution
         private static uint Execute(IntPtr address, uint timeoutSeconds = 0xFFFFFFFF)

--- a/Util/PlatformMemory.cs
+++ b/Util/PlatformMemory.cs
@@ -177,6 +177,9 @@ namespace Archipelago.Core.Util.PlatformMemory
         {
             return PlatformImpl.GetLastErrorMessage();
         }
+        
+        public static bool HasDirectMapping => PlatformImpl is LinuxMemory linux && linux.IsSharedMemoryAttached;
+        
         #endregion
 
         #region Memory Operations

--- a/Util/PlatformMemory/ElevationHelper.cs
+++ b/Util/PlatformMemory/ElevationHelper.cs
@@ -3,6 +3,7 @@ using System.ComponentModel;
 using System.Diagnostics;
 using System.Runtime.InteropServices;
 using System.Security.Principal;
+using Serilog;
 
 namespace Archipelago.Core.Util.PlatformMemory
 {
@@ -54,8 +55,34 @@ namespace Archipelago.Core.Util.PlatformMemory
         /// </summary>
         public static bool RequiresElevation(int processId)
         {
+            
+            
             if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
+                // More accurate method of checking elevation on Linux, not sure how maxOS behaves, but might be foldable into this as well.
+                // Some processes may make their memory dumpable.
+                if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux)) {
+                    try {
+                        var procInfo = System.IO.File.ReadAllLines($"/proc/{processId}/status");
+                        return procInfo.Any(s => {
+                            bool containsDumpable = s.StartsWith("Dumpable:", StringComparison.Ordinal);
+                            if (!containsDumpable) {
+                                return false;
+                            }
+
+                            int dumpableStatus;
+                            if (int.TryParse(s.Split(":")[1], out dumpableStatus)) {
+                                return containsDumpable && dumpableStatus > 0;
+                            }
+                            // shouldn't really throw this type of exception here, but it allows us to fail loudly while still falling back under predictable fail cases
+                            throw new IOException("Failed to parse process status.");
+                        });
+                    }
+                    catch (IOException) {
+                        Log.Logger.Information($"Failed to read '/proc/${processId}/status' to get elevation info, will try fallback.");
+                    }
+                }
+                
                 // On Linux/macOS, check if /proc/{pid}/mem is readable
                 try
                 {

--- a/Util/PlatformMemory/LinuxMemory.cs
+++ b/Util/PlatformMemory/LinuxMemory.cs
@@ -53,6 +53,21 @@ namespace Archipelago.Core.Util.PlatformMemory
         private const uint PAGE_READONLY = 0x02;
         private const uint MEM_COMMIT = 0x00001000;
         private const uint MEM_RELEASE = 0x00008000;
+        
+        // Direct shared-memory attach (shm_open + mmap)
+        private const int MAP_SHARED = 0x01;
+        private const int O_RDWR = 0x2;
+        private const int SEEK_SET = 0;
+        private const int SEEK_END = 2;
+
+        [DllImport("libc.so.6", EntryPoint = "shm_open", SetLastError = true)]
+        private static extern int shm_open(string name, int oflag, int mode);
+
+        [DllImport("libc.so.6", EntryPoint = "close", SetLastError = true)]
+        private static extern int close(int fd);
+
+        [DllImport("libc.so.6", EntryPoint = "lseek", SetLastError = true)]
+        private static extern long lseek(int fd, long offset, int whence);
         #endregion
 
         #region Structures
@@ -385,11 +400,110 @@ namespace Archipelago.Core.Util.PlatformMemory
             }
         }
         #endregion
+        
+        #region Direct Shared-memory Attach
+        private nint _shmLocalBase;
+        private nint _shmRemoteBase;
+        private long _shmSize;
+        private bool _shmAttached;
+
+        /// <summary>
+        /// Opens a named POSIX shared-memory object and maps it into this process, then
+        /// registers it so ReadProcessMemory/WriteProcessMemory read/write through the
+        /// mapping. <paramref name="remoteBase"/> is the object's
+        /// base address in the target process, used to translate addresses.
+        ///
+        /// NOTE: The Direct shared-memory attach region was AI-generated, since it is mostly just common memory-management boilerplate.
+        /// I audited and touched it up a little, but if something breaks, check here first.
+        /// </summary>
+        public nint AttachSharedMemory(string shmName, ulong remoteBase)
+        {
+            if (_shmAttached)
+                return _shmLocalBase;
+
+            int fd = shm_open(shmName, O_RDWR, 0);
+            if (fd < 0)
+            {
+                Log.Logger.Warning($"shm_open('{shmName}') failed: {GetLastErrorMessage()}");
+                return nint.Zero;
+            }
+
+            long size = lseek(fd, 0, SEEK_END);
+            if (size <= 0 || lseek(fd, 0, SEEK_SET) < 0)
+            {
+                close(fd);
+                Log.Logger.Warning($"Could not determine size of shared memory '{shmName}'");
+                return nint.Zero;
+            }
+
+            nint localBase = mmap(nint.Zero, (ulong)size, PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
+            close(fd); // mapping keeps the object alive
+
+            if (localBase.ToInt64() == -1)
+            {
+                Log.Logger.Error($"mmap of shared memory '{shmName}' failed: {GetLastErrorMessage()}");
+                return nint.Zero;
+            }
+
+            _shmLocalBase = localBase;
+            _shmRemoteBase = new nint((long)remoteBase);
+            _shmSize = size;
+            _shmAttached = true;
+
+            Log.Logger.Information($"Attached shared memory '{shmName}' ({size} bytes) at 0x{localBase:X} (remote base 0x{remoteBase:X})");
+            return localBase;
+        }
+
+        private bool TryReadMapped(ulong address, byte[] buffer, int length, out nint bytesRead)
+        {
+            bytesRead = nint.Zero;
+            if (!_shmAttached)
+                return false;
+
+            ulong remoteBase = (ulong)_shmRemoteBase.ToInt64();
+            if (address < remoteBase)
+                return false;
+
+            ulong offset = address - remoteBase;
+            if (offset + (ulong)length > (ulong)_shmSize)
+                return false;
+
+            Marshal.Copy(new nint(_shmLocalBase.ToInt64() + (long)offset), buffer, 0, length);
+            bytesRead = new nint(length);
+            return true;
+        }
+
+        private bool TryWriteMapped(ulong address, byte[] buffer, int length, out nint bytesWritten)
+        {
+            bytesWritten = nint.Zero;
+            if (!_shmAttached)
+                return false;
+
+            ulong remoteBase = (ulong)_shmRemoteBase.ToInt64();
+            if (address < remoteBase)
+                return false;
+
+            ulong offset = address - remoteBase;
+            if (offset + (ulong)length > (ulong)_shmSize)
+                return false;
+
+            Marshal.Copy(buffer, 0, new nint(_shmLocalBase.ToInt64() + (long)offset), length);
+            bytesWritten = new nint(length);
+            return true;
+        }
+
+        #endregion
 
         #region Memory Operations
         public bool ReadProcessMemory(nint processH, ulong lpBaseAddress, byte[] lpBuffer, int dwSize, out nint lpNumberOfBytesRead)
         {
             lpNumberOfBytesRead = nint.Zero;
+            // Fast path: read directly from the attached shared-memory mapping.
+            if (TryReadMapped(lpBaseAddress, lpBuffer, dwSize, out nint mappedRead))
+            {
+                lpNumberOfBytesRead = mappedRead;
+                return true;
+            }
             int pid = processH.ToInt32();
 
             if (pid <= 0)
@@ -455,6 +569,11 @@ namespace Archipelago.Core.Util.PlatformMemory
         public bool WriteProcessMemory(nint processH, ulong lpBaseAddress, byte[] lpBuffer, int dwSize, out nint lpNumberOfBytesWritten)
         {
             lpNumberOfBytesWritten = nint.Zero;
+            if (TryWriteMapped(lpBaseAddress, lpBuffer, dwSize, out nint mappedWritten))
+            {
+                lpNumberOfBytesWritten = mappedWritten;
+                return true;
+            }
             int pid = processH.ToInt32();
 
             if (pid <= 0)
@@ -939,6 +1058,34 @@ namespace Archipelago.Core.Util.PlatformMemory
                 Log.Logger.Error($"Error getting module base address on Linux: {ex.Message}");
                 return nint.Zero;
             }
+        }
+        
+        public nint FindSharedMemoryBase(int pid, string nameSubstring)
+        {
+            try
+            {
+                string mapsPath = $"/proc/{pid}/maps";
+                foreach (string line in File.ReadAllLines(mapsPath))
+                {
+                    if (!line.Contains(nameSubstring, StringComparison.OrdinalIgnoreCase))
+                        continue;
+                    if (!line.Contains("/dev/shm/", StringComparison.OrdinalIgnoreCase) &&
+                        !line.Contains("memfd:", StringComparison.OrdinalIgnoreCase))
+                        continue;
+
+                    string[] parts = line.Split(' ', StringSplitOptions.RemoveEmptyEntries);
+                    string[] addresses = parts[0].Split('-');
+                    return new nint((long)Convert.ToUInt64(addresses[0], 16));
+                }
+
+                Log.Logger.Warning($"Could not find shared memory region '{nameSubstring}' in process {pid}");
+            }
+            catch (Exception ex)
+            {
+                Log.Logger.Error($"Error reading memory maps for process {pid}: {ex.Message}");
+            }
+
+            return nint.Zero;
         }
         #endregion
 

--- a/Util/PlatformMemory/LinuxMemory.cs
+++ b/Util/PlatformMemory/LinuxMemory.cs
@@ -406,6 +406,8 @@ namespace Archipelago.Core.Util.PlatformMemory
         private nint _shmRemoteBase;
         private long _shmSize;
         private bool _shmAttached;
+        
+        public bool IsSharedMemoryAttached => _shmAttached;
 
         /// <summary>
         /// Opens a named POSIX shared-memory object and maps it into this process, then


### PR DESCRIPTION
Two fixes/fallbacks added:
Firstly - tries to attached to named shm for PCSX2, currently won't work but should be supported soon pending the upstream PR getting merged

Secondly - tries to attach directly to PCSX2 process running and get the memory that way. This method requires the user to modify the pcsx2-qt binary and modify the sysctl state, which would open a security hole, so it's preferred as a 'last-resort' option.

This will be documented downstream, but you essentially need to do two things:
`sudo setcap -r /usr/bin/pcsx2-qt`
and
`echo 0 | sudo tee /proc/sys/kernel/yama/ptrace_scope`

Top command applies to binary and will be overwritten on a new build, bottom change is ephemeral and will clear on reboot, but can also be made permanent with an additional command if the user likes to live life on the edge.

Top command can be reversed currently by running:
`sudo setcap cap_net_admin,cap_net_raw=eip /usr/bin/pcsx2-qt`

Bottom command is reversed on reboot or by swapping the 0 for a 1 and rerunning the command.

Note: Most of this PR is hand-written, but specifically the new region in LinuxMemory.cs called 'Direct Shared-memory Attach' is AI-generated boilerplate that I audited and tweaked.